### PR TITLE
Use log config files and fallback

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ show-source = True
 
 [pep8]
 max-line-length = 100
-exclude = .env/*,.tmp/*,doc/*,tests/*
+exclude = .env/*,.tmp/*,doc/*,tests/*,build/*
 
 [pycodestyle]
 max-line-length = 100

--- a/src/rstxml2db/__init__.py
+++ b/src/rstxml2db/__init__.py
@@ -31,5 +31,6 @@ __email__ = "toms (AT) suse DOT de"
 __license__ = "GPL-3.0"
 __summary__ = __doc__
 
+
 # Set default logging handler to avoid "No handler found" warnings.
 logging.getLogger().addHandler(logging.NullHandler())

--- a/src/rstxml2db/cli.py
+++ b/src/rstxml2db/cli.py
@@ -49,26 +49,6 @@ else:
 
 log = logging.getLogger(__name__)
 
-## Just for testing the two loggers:
-# log.error("This is an error message!")
-# log.warning("This is a warning message")
-# log.debug("Debug message")
-# log.info("Info message")
-#
-# logging.info("root info")
-# logging.debug("root debug")
-# logging.warning("root warning")
-# logging.error("root error!")
-# logging.critical("root critical!")
-
-
-# def level2name():
-#    """Map level to log name
-#    """
-#    log = logging.getLogger(__name__)
-#    level = log.getEffectiveLevel()
-#    return "%s(%s)" % (LOGNAMES.get(level, 'NOTSET'), level)
-
 
 def prepareparams(params):
     """Convert the list with "NAME=VALUE" entries into
@@ -163,13 +143,13 @@ def parsecli(cliargs=None):
     args = parser.parse_args(args=cliargs)
     log.setLevel(LOGLEVELS.get(args.verbose, logging.NOTSET))
     args.params = prepareparams(args.params)
-    #if False:
-        #log.debug("Arguments: %s", args)
-        #log.debug('test debug message')
-        #log.info('test info message')
-        #log.warning('test warn message')
-        #log.error('test error message')
-        #log.critical('test critical message')
+    # if False:
+    #    log.debug("Arguments: %s", args)
+    #    log.debug('test debug message')
+    #    log.info('test info message')
+    #    log.warning('test warn message')
+    #    log.error('test error message')
+    #    log.critical('test critical message')
     # log.critical('effective verbose=%s, level=%s',
     #             args.verbose, level2name())
     # log.error('test error message')

--- a/src/rstxml2db/core.py
+++ b/src/rstxml2db/core.py
@@ -21,11 +21,16 @@ Core variables, used in other modules.
 """
 
 import os
-import logging
-
-
-__all__ = ('DOCTYPE', 'HERE', 'NSMAP',
-           'XSLTRST2DB', 'XSLTRESOLVE', 'XSLTDB4TO5')
+from logging import (BASIC_FORMAT,
+                     CRITICAL,
+                     DEBUG,
+                     FATAL,
+                     ERROR,
+                     INFO,
+                     NOTSET,
+                     WARN,
+                     WARNING,
+                     )
 
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -57,8 +62,62 @@ DOCTYPE = r"""<!DOCTYPE {} PUBLIC
 -->
 ]>"""
 
-LOGLEVELS = {None: logging.NOTSET,  # 0
-             0: logging.NOTSET,
-             1: logging.INFO,
-             2: logging.DEBUG,
+#: Map verbosity to log levels
+LOGLEVELS = {None: WARNING,  # 0
+             0: WARNING,
+             1: INFO,
+             2: DEBUG,
              }
+
+#: Map log numbers to log names
+LOGNAMES = { NOTSET: 'NOTSET',     # 0
+             None:  'NOTSET',
+             DEBUG:  'DEBUG',      # 10
+             INFO:   'INFO',       # 20
+             WARN:    'WARNING',   # 30
+             WARNING: 'WARNING',   # 30
+             ERROR:  'ERROR',      # 40
+             CRITICAL: 'CRITICAL', # 50
+             FATAL: 'CRITICAL',    # 50
+             }
+
+#: log config files to search for
+LOGFILECONFIGS = (os.path.join(os.path.dirname(__file__),
+                               'logging.conf'),
+                  os.path.expanduser("~/.config/rstxml2db/logging.conf"),
+                  )
+
+DEBUG_FORMAT = "[%(levelname)s] %(name)s:%(lineno)s %(message)s"
+# SIMPLE_FORMAT = "%(levelname)s:%(name)s:%(message)s"
+
+LOG_CONFIG = {
+        'version': 1,
+        'formatters': {'rstxml2db': {'format': DEBUG_FORMAT,
+                                     'datefmt': '%Y%m%dT%H:%M:%S'},
+                       'default': {'format': BASIC_FORMAT,
+                                   'datefmt': '%Y-%m-%d %H:%M:%S'},
+                       },
+        'handlers': {
+            'console': {
+                'class': 'logging.StreamHandler',
+                'level': 'NOTSET',
+                'formatter': 'default',
+            },
+            'rstxml2db': {
+                'class': 'logging.StreamHandler',
+                'level': 'DEBUG',
+                'formatter': 'rstxml2db',
+            },
+        },
+        'loggers': {
+            'rstxml2db': {
+                'handlers': ['rstxml2db'],
+                'propagate': False,
+            }
+        },
+        'root': {
+            'level': 'DEBUG',
+            # Default %(levelname)s:%(name)s:%(message)s
+            # 'handlers': ['console'],
+        },
+    }

--- a/src/rstxml2db/core.py
+++ b/src/rstxml2db/core.py
@@ -70,16 +70,16 @@ LOGLEVELS = {None: WARNING,  # 0
              }
 
 #: Map log numbers to log names
-LOGNAMES = { NOTSET: 'NOTSET',     # 0
-             None:  'NOTSET',
-             DEBUG:  'DEBUG',      # 10
-             INFO:   'INFO',       # 20
-             WARN:    'WARNING',   # 30
-             WARNING: 'WARNING',   # 30
-             ERROR:  'ERROR',      # 40
-             CRITICAL: 'CRITICAL', # 50
-             FATAL: 'CRITICAL',    # 50
-             }
+LOGNAMES = {NOTSET: 'NOTSET',      # 0
+            None:  'NOTSET',
+            DEBUG:  'DEBUG',       # 10
+            INFO:   'INFO',        # 20
+            WARN:    'WARNING',    # 30
+            WARNING: 'WARNING',    # 30
+            ERROR:  'ERROR',       # 40
+            CRITICAL: 'CRITICAL',  # 50
+            FATAL: 'CRITICAL',     # 50
+            }
 
 #: log config files to search for
 LOGFILECONFIGS = (os.path.join(os.path.dirname(__file__),
@@ -87,9 +87,10 @@ LOGFILECONFIGS = (os.path.join(os.path.dirname(__file__),
                   os.path.expanduser("~/.config/rstxml2db/logging.conf"),
                   )
 
+#: logging format for debugging purposes
 DEBUG_FORMAT = "[%(levelname)s] %(name)s:%(lineno)s %(message)s"
-# SIMPLE_FORMAT = "%(levelname)s:%(name)s:%(message)s"
 
+#: fallback logging configuration
 LOG_CONFIG = {
         'version': 1,
         'formatters': {'rstxml2db': {'format': DEBUG_FORMAT,


### PR DESCRIPTION
Changes proposed in this pull request:

* Provide log config files in library path and `~/.config/rstxml2db/logging.conf`
* Provide default logging config in LOG_CONFIG if files cannot be found
* Provide default value of zero vor `--verbose` option
