### PR TITLE
Support manpage macro (fix #18)

### DIFF
--- a/src/rstxml2db/rstxml2db.xsl
+++ b/src/rstxml2db/rstxml2db.xsl
@@ -315,6 +315,10 @@
     <xsl:apply-templates select="paragraph[position()>1]"/>
   </xsl:template>
 
+  <xsl:template match="manpage">
+    <xsl:apply-templates/>
+  </xsl:template>
+
   <xsl:template match="literal_block[@language='shell' or @language='console']">
     <screen>
       <xsl:apply-templates/>

--- a/tests/data/manpage-001.params.json
+++ b/tests/data/manpage-001.params.json
@@ -1,0 +1,3 @@
+[
+    ["contains(//d:para, 'bind(2)')", true]
+]

--- a/tests/data/manpage-001.xml
+++ b/tests/data/manpage-001.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+<!DOCTYPE document PUBLIC
+  "+//IDN docutils.sourceforge.net//DTD Docutils Generic//EN//XML"
+  "http://docutils.sourceforge.net/docs/ref/docutils.dtd">
+-->
+
+<document source="manpage.001.rst">
+ <section ids="manpage">
+  <title>Manpage Test</title>
+  <paragraph>See manpage <manpage classes="manpage"
+    page="bind"
+    path="bind(2)"
+    section="2"
+    xml:space="preserve">bind(2)</manpage>.
+  </paragraph>  
+ </section>
+</document>


### PR DESCRIPTION
Fixes #18

Changes proposed in this pull request:

* Improve `rstxml2db.xsl` stylesheet to copy `<manpage>` tag into DocBook output.
* Add test case