### PR TITLE
Fix #23, implement --help-xsl-param

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,6 +10,8 @@ engines:
         enabled: true
     radon:
         enabled: true
+        config: 
+            threshold: "C"
     fixme:
         enabled: true
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -17,6 +17,7 @@ ignore_errors = True
 omit =
     tests/*
     test/*
+    */rstxml2db/__main__.py
 
 [html]
 title = rstxml2docbook Coverage Report

--- a/src/rstxml2db/cli.py
+++ b/src/rstxml2db/cli.py
@@ -213,7 +213,7 @@ def parsecli(cliargs=None):
     args.params = prepareparams(args.params)
     log.info(args)
 
-    return check_arguments(args)
+    return check_arguments(parser, args)
 
 
 def main(cliargs=None):

--- a/src/rstxml2db/cli.py
+++ b/src/rstxml2db/cli.py
@@ -35,7 +35,7 @@ from .xml import process
 # fileConfig needs to come first before
 lastfound = None
 # We iterate from the last item as the
-for s in reversed(LOGFILECONFIGS):
+for s in reversed(LOGFILECONFIGS):  # pragma: no cover
     if exists(s):
         # If a file could be found, we are finish so break the loop
         lastfound = s
@@ -45,7 +45,7 @@ if lastfound:
     fileConfig(lastfound)
 else:
     # Provide minimum logging setup, if config files not found
-    logging.config.dictConfig(LOG_CONFIG)
+    logging.config.dictConfig(LOG_CONFIG)  # pragma: no cover
 
 log = logging.getLogger(__name__)
 

--- a/src/rstxml2db/core.py
+++ b/src/rstxml2db/core.py
@@ -49,6 +49,9 @@ XSLTDB4TO5 = os.path.join(HERE, 'suse-upgrade.xsl')
 NSMAP = dict(xi='http://www.w3.org/2001/XInclude',
              d='http://docbook.org/ns/docbook',
              xl='http://www.w3.org/1999/xlink',
+             xsl='http://www.w3.org/1999/XSL/Transform',
+             # Namespace inside XSLT, used to describe xsl:param's:
+             doc='urn:x-suse:xslt-doc',
              )
 
 #: DOCTYPE declaration with placeholders

--- a/src/rstxml2db/rstxml2db.xsl
+++ b/src/rstxml2db/rstxml2db.xsl
@@ -30,23 +30,23 @@
 <xsl:stylesheet version="1.0"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:exsl="http://exslt.org/common"
-  exclude-result-prefixes="exsl">
+  xmlns:doc="urn:x-suse:xslt-doc"
+  exclude-result-prefixes="exsl doc">
 
   <xsl:output indent="yes"/>
   <xsl:strip-space elements="*"/>
 
+  <!-- Keys =============================================================-->
   <xsl:key name="id" match="*" use="@ids"/>
   <xsl:key name="documents" match="document" use="@source"/>
 
-  <xsl:param name="xml.ext">.xml</xsl:param>
+  <!-- Parameters =======================================================-->
+  <xsl:param name="xml.ext" doc:descr="Extension for referenced files">.xml</xsl:param>
+  <xsl:param name="rootlang" doc:descr="Natural language for root element">en</xsl:param>
+  <xsl:param name="productname" doc:descr="The product name, empty by default"/>
+  <xsl:param name="productnumber" doc:descr="The product number, empty by default"/>
 
-  <!-- Natural language for root element -->
-  <xsl:param name="rootlang">en</xsl:param>
-
-  <xsl:param name="productname"/>
-  <xsl:param name="productnumber"/>
-
-
+  <!-- Templates ======================================================= -->
   <xsl:template match="*">
     <xsl:message>WARN: Unknown element '<xsl:value-of select="local-name()"/>'</xsl:message>
   </xsl:template>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 
+import argparse
 import pytest
-from rstxml2db.cli import prepareparams, parsecli
+from rstxml2db.cli import prepareparams, parsecli, print_all_xsl_params
 
 
 @pytest.mark.parametrize('params, expected', [
@@ -92,3 +93,11 @@ def test_parsecli(cli, expected):
     diff = set(result.__dict__) & set(expected)
     result = {i: getattr(result, i) for i in diff}
     assert result == expected
+
+
+def test_print_all_xsl_params(capsys):
+    parser = argparse.ArgumentParser(description="test")
+    with pytest.raises(SystemExit):
+        print_all_xsl_params(parser)
+    captured = capsys.readouterr()
+    assert len(captured.out.split('\n')) > 1


### PR DESCRIPTION
Fixes #23 .

Changes proposed in this pull request:

* Implement `--help-xsl-param` option

Currently, we have to mark INDEXFILE as optional here, because we can't use a mutually exclusive group with `--help-xsl-param`. :-(


