### PR TITLE
Test reference[@refuri]

### DIFF
--- a/src/rstxml2db/rstxml2db.xsl
+++ b/src/rstxml2db/rstxml2db.xsl
@@ -771,13 +771,14 @@
 
   <xsl:template match="reference[@refuri]">
     <ulink url="{@refuri}">
-      <xsl:value-of select="."/>
+      <xsl:if test="@refuri != .">
+       <xsl:value-of select="."/>
+      </xsl:if>
     </ulink>
   </xsl:template>
 
   <xsl:template match="reference[@refuri][@internal='True']">
     <xsl:variable name="uri" select="substring-after(@refuri, '#')"/>
-
     <xsl:choose>
       <xsl:when test="$uri != ''">
         <xref linkend="{$uri}"/>

--- a/tests/data/reference-001.params.json
+++ b/tests/data/reference-001.params.json
@@ -1,0 +1,5 @@
+[
+    ["count(/*/*/d:para/d:link)", 2],
+    ["/*/*/d:para[1]/d:link/text()", []],
+    ["/*/*/d:para[2]/d:link/text()", ["Tux"]]
+]

--- a/tests/data/reference-001.xml
+++ b/tests/data/reference-001.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document source="reference-001.rst">
+ <section ids="reference">
+  <title>Test References</title>
+  <section>
+   <title>References</title>
+   <paragraph>See <reference refuri="http://www.example.org"
+     >http://www.example.org</reference>. </paragraph>
+   <paragraph>See <reference refuri="http://tux.example.org">Tux</reference>.
+   </paragraph>
+  </section>
+ </section>
+</document>

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -95,4 +95,5 @@ def test_xmltestcases(xmltestcase, args):
     resultxmlstr = etree.tostring(resultxml, encoding="unicode")
 
     for xpath, expected in params:
-        assert resultxml.xpath(xpath, namespaces=NSMAP) == expected
+        result = resultxml.xpath(xpath, namespaces=NSMAP)
+        assert result == expected


### PR DESCRIPTION
Changes proposed in this pull request:

When `<references>` contains both `@refuri` and text, add text only to `<ulink>` when it is different from `@refuri`.
