### PR TITLE
Copy namespace nodes to root element

### DIFF
--- a/tests/doc.003/docbook.xml
+++ b/tests/doc.003/docbook.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<chapter xmlns="http://docbook.org/ns/docbook" version="5.1">
+ <title>Hello World</title>
+ <section xml:base="tux">
+  <title>Hello from Tux</title>
+  <para>I'm Tux</para>
+ </section>
+
+ <section xml:base="wilber">
+  <title>Hello from Wilber</title>
+  <para>I'm Wilber</para>
+ </section>
+ 
+</chapter>

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -278,13 +278,24 @@ def test_multiple_output_files_with_root_ns(tmpdir):
     #set the tmpdir and the indexfile
     DOCDIR = HERE / 'doc.003'
     DOCDIR.copy(tmpdir)
-    outdir = str(tmpdir / "out") + "/"
+    outdir = tmpdir.mkdir("out")
 
     # params = dict()
-    params = {'basedir':  etree.XSLT.strparam(outdir)}
+    params = {'basedir':  etree.XSLT.strparam(outdir.strpath+"/")}
     xml = etree.parse(str(tmpdir / "docbook.xml"))
     trans = etree.XSLT(etree.parse(XSLTSPLIT))
     trans(xml, **params)
 
     assert outdir.exists()
+    assert len(outdir.listdir()) == 3
+
+    # We need to test, if root element have more than one namespace:
+    for xmlfile in outdir.listdir():
+        xml = etree.parse(xmlfile.strpath)
+        nsmap = (xml.getroot()).nsmap
+        assert xml.getroot().attrib.get('version')
+        assert len(nsmap) > 1
+        set(nsmap.values()) == set(['http://docbook.org/ns/docbook',
+                                    'http://www.w3.org/1999/xlink',
+                                    'http://www.w3.org/2001/XInclude'])
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,7 +1,7 @@
 #
 
 from rstxml2db.xml.process import process
-from rstxml2db.core import NSMAP
+from rstxml2db.core import NSMAP, XSLTSPLIT
 
 from lxml import etree
 from py.path import local
@@ -257,6 +257,7 @@ def test_single_output_file(tmpdir, args):
    tree = etree.parse(args.output)
    assert tree.xpath('/d:book', namespaces=NSMAP)
 
+
 def test_multiple_output_files(tmpdir, args):
    #set the tmpdir and the indexfile
    DOCDIR = HERE / 'doc.002'
@@ -271,4 +272,19 @@ def test_multiple_output_files(tmpdir, args):
 
    assert outdir.exists()
    assert len(outdir.listdir()) == 2
+
+
+def test_multiple_output_files_with_root_ns(tmpdir):
+    #set the tmpdir and the indexfile
+    DOCDIR = HERE / 'doc.003'
+    DOCDIR.copy(tmpdir)
+    outdir = str(tmpdir / "out") + "/"
+
+    # params = dict()
+    params = {'basedir':  etree.XSLT.strparam(outdir)}
+    xml = etree.parse(str(tmpdir / "docbook.xml"))
+    trans = etree.XSLT(etree.parse(XSLTSPLIT))
+    trans(xml, **params)
+
+    assert outdir.exists()
 


### PR DESCRIPTION
Fixes #35 

Changes proposed in this pull request:

* Copy namespace nodes into root element
* Add `version` attribute
