### PR TITLE
Fix #55: correct entry/inline elements

### DIFF
--- a/src/rstxml2db/rstxml2db.xsl
+++ b/src/rstxml2db/rstxml2db.xsl
@@ -35,7 +35,7 @@
   xmlns:doc="urn:x-suse:xslt-doc"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xl="http://www.w3.org/1999/xlink"
-  exclude-result-prefixes="exsl doc">
+  exclude-result-prefixes="exsl doc d xi xl">
 
   <xsl:output indent="yes"/>
   <xsl:strip-space elements="*"/>
@@ -599,6 +599,41 @@
     </colspec>
   </xsl:template>
 
+  <xsl:template match="row" mode="table">
+    <row>
+      <xsl:apply-templates mode="table"/>
+    </row>
+  </xsl:template>
+
+  <xsl:template match="tbody" mode="table">
+    <tbody>
+      <xsl:apply-templates mode="table"/>
+    </tbody>
+  </xsl:template>
+  <xsl:template match="thead" mode="table">
+    <thead>
+      <xsl:apply-templates mode="table"/>
+    </thead>
+  </xsl:template>
+
+  <xsl:template match="tgroup" mode="table">
+    <tgroup>
+      <xsl:apply-templates mode="table"/>
+    </tgroup>
+  </xsl:template>
+  
+
+  <xsl:template match="entry" mode="table">
+    <entry>
+      <xsl:apply-templates mode="table"/>
+    </entry>
+  </xsl:template>
+
+  <xsl:template match="entry/*[not(self::paragraph)]" mode="table">
+    <para>
+      <xsl:apply-templates/>
+    </para>
+  </xsl:template>
 
   <xsl:template match="paragraph" mode="table">
     <para>
@@ -610,6 +645,8 @@
     <xsl:apply-templates select="."/>
   </xsl:template>
 
+
+  <!-- =================================================================== -->
   <xsl:template match="option_list">
    <variablelist>
     <xsl:apply-templates/>
@@ -911,6 +948,10 @@
 
   <xsl:template match="reference[@refid]">
     <xref linkend="{@refid}"/>
+  </xsl:template>
+
+  <xsl:template match="entry/inline/reference[@refid]">
+    <link xl:href="#{@refid}"><xsl:apply-templates/></link>
   </xsl:template>
 
   <xsl:template match="title_reference">

--- a/tests/data/table-001.params.json
+++ b/tests/data/table-001.params.json
@@ -1,0 +1,8 @@
+[
+    ["count(//d:tgroup/d:colspec)", 4],
+    ["count(//d:entry[d:para])", 4],
+    ["boolean(//d:entry[1]/d:para/d:link/d:emphasis)", true],
+    ["boolean(/*/*/d:tgroup)", true],
+    ["//d:entry[3]/d:para/d:*/d:literal/text()", ["✔"]],
+    ["//d:entry[4]/d:para/d:*/d:literal/text()", ["✔"]]
+]

--- a/tests/data/table-001.xml
+++ b/tests/data/table-001.xml
@@ -1,0 +1,41 @@
+<!--<!DOCTYPE document PUBLIC
+  "+//IDN docutils.sourceforge.net//DTD Docutils Generic//EN//XML"
+  "http://docutils.sourceforge.net/docs/ref/docutils.dtd">-->
+
+<document source="table.001.rst">
+  <target refid="table"/>
+  <section ids="table table" names="test\ tables tables">
+    <title>Test Tables</title>
+    <paragraph>The following structure is a table:</paragraph>
+
+    <table>
+      <tgroup cols="4">
+        <colspec colwidth="1"/>
+        <colspec colwidth="1"/>
+        <colspec colwidth="1"/>
+        <colspec colwidth="1"/>
+        <tbody>
+          <row>
+            <entry>
+              <inline><reference refid="operation_create_unscoped_token"
+                    ><strong>Create unscoped token</strong></reference></inline>
+            </entry>
+            <entry>
+              <inline classes="sp_feature_mandatory">mandatory</inline>
+            </entry>
+            <entry>
+              <inline><reference refid="operation_create_unscoped_token_fernet"
+                    ><literal classes="sp_impl_summary sp_impl_complete"
+                    >✔</literal></reference></inline>
+            </entry>
+            <entry>
+              <inline><reference refid="operation_create_unscoped_token_uuid"
+                    ><literal classes="sp_impl_summary sp_impl_complete"
+                    >✔</literal></reference></inline>
+            </entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </section>
+</document>


### PR DESCRIPTION
Fixes #55 .

The support_matrix directive creates a table which contains inline
elements inside entry. This lead to validation errors after the
conversion.

Changes proposed in this pull request:

* Add several table related templates to add <para> around inline elements.
* Add testcases

