### PR TITLE
Fix #57: ignore references in TOC to remote URL

### DIFF
--- a/src/rstxml2db/resolve.xsl
+++ b/src/rstxml2db/resolve.xsl
@@ -60,11 +60,19 @@
   <xsl:template match="list_item[@classes='toctree-l1']" mode="xinclude">
     <xsl:variable name="refuri" select="*/reference/@refuri"/>
     <xsl:variable name="ref" select="concat($refuri, $xml.ext)"/>
-    <xsl:message>INFO: Including "<xsl:value-of select="$ref"/>"...</xsl:message>
-    <xsl:apply-templates select="document($ref, .)">
-      <xsl:with-param name="role" select="''"/>
-      <xsl:with-param name="xmlbase" select="$refuri"/>
-    </xsl:apply-templates>
+
+    <xsl:choose>
+      <xsl:when test=" starts-with($refuri, 'http')">
+        <xsl:message>WARNING: Cannot include "<xsl:value-of select="$ref"/>"; ignored</xsl:message>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:message>INFO: Including "<xsl:value-of select="$ref"/>"...</xsl:message>
+        <xsl:apply-templates select="document($ref, .)">
+          <xsl:with-param name="role" select="''"/>
+          <xsl:with-param name="xmlbase" select="$refuri"/>
+        </xsl:apply-templates>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/tests/data/document-003.params.json
+++ b/tests/data/document-003.params.json
@@ -1,0 +1,8 @@
+[
+    ["namespace-uri(/*)", "http://docbook.org/ns/docbook"],
+    ["local-name(/*)", "book"],
+    ["/*/@xml:lang", ["en"]],
+    ["boolean(/d:book/d:chapter/d:title/text())", true],
+    ["boolean(/d:book/d:chapter/d:para/text())", true],
+    ["/d:book/d:chapter/d:para/text()", ["Found!"]]
+]

--- a/tests/data/document-003.xml
+++ b/tests/data/document-003.xml
@@ -1,0 +1,30 @@
+<!--<!DOCTYPE document PUBLIC
+  "+//IDN docutils.sourceforge.net//DTD Docutils Generic//EN//XML"
+  "http://docutils.sourceforge.net/docs/ref/docutils.dtd">-->
+
+<!DOCTYPE document SYSTEM "docutils.dtd">
+<document source="document.003.rst">
+  <section ids="foo" names="foo">
+    <title>Foo</title>
+    <paragraph>I'm the foo para.</paragraph>
+    <compound classes="toctree-wrapper">
+      <compact_paragraph toctree="True">
+        <bullet_list>
+          <list_item classes="toctree-l1">
+            <compact_paragraph classes="toctree-l1">
+              <reference anchorname="" internal="True"
+                refuri="document-001">Document 001</reference>
+            </compact_paragraph>
+          </list_item>
+          <!--<list_item classes="toctree-l1">
+                            <compact_paragraph classes="toctree-l1">
+                                <reference anchorname="" internal="False"
+                                    refuri="https://developer.openstack.org/api-ref/baremetal/"
+                                    >API Reference (latest)</reference>
+                            </compact_paragraph>
+                        </list_item>-->
+        </bullet_list>
+      </compact_paragraph>
+    </compound>
+  </section>
+</document>

--- a/tests/data/document-004.params.json
+++ b/tests/data/document-004.params.json
@@ -1,0 +1,8 @@
+[
+    ["namespace-uri(/*)", "http://docbook.org/ns/docbook"],
+    ["local-name(/*)", "book"],
+    ["/*/@xml:lang", ["en"]],
+    ["boolean(/d:book/d:chapter/d:title/text())", true],
+    ["boolean(/d:book/d:chapter/d:para/text())", true],
+    ["/d:book/d:chapter/d:para/text()", ["Found!"]]
+]

--- a/tests/data/document-004.xml
+++ b/tests/data/document-004.xml
@@ -1,0 +1,30 @@
+<!--<!DOCTYPE document PUBLIC
+  "+//IDN docutils.sourceforge.net//DTD Docutils Generic//EN//XML"
+  "http://docutils.sourceforge.net/docs/ref/docutils.dtd">-->
+
+<!DOCTYPE document SYSTEM "docutils.dtd">
+<document source="document.004.rst">
+  <section ids="foo" names="foo">
+    <title>Foo</title>
+    <paragraph>I'm the foo para.</paragraph>
+    <compound classes="toctree-wrapper">
+      <compact_paragraph toctree="True">
+        <bullet_list>
+          <list_item classes="toctree-l1">
+            <compact_paragraph classes="toctree-l1">
+              <reference anchorname="" internal="True" refuri="document-001"
+                >Document 001</reference>
+            </compact_paragraph>
+          </list_item>
+          <list_item classes="toctree-l1">
+            <compact_paragraph classes="toctree-l1">
+              <reference anchorname="" internal="False"
+                refuri="https://developer.openstack.org/api-ref/baremetal/">API
+                Reference (latest)</reference>
+            </compact_paragraph>
+          </list_item>
+        </bullet_list>
+      </compact_paragraph>
+    </compound>
+  </section>
+</document>


### PR DESCRIPTION
Fixes #57.

Changes proposed in this pull request:

* Fix `resolve.xsl` to check for `http` protocol; if yes, ignore the URL.
* Add testcases
