### PR TITLE
Fix #63: literal/@classes='sp_cli' -> screen

### DIFF
--- a/src/rstxml2db/rstxml2db.xsl
+++ b/src/rstxml2db/rstxml2db.xsl
@@ -353,7 +353,8 @@
     <xsl:apply-templates/>
   </xsl:template>
 
-  <xsl:template match="literal_block[@language='shell' or @language='console']">
+  <xsl:template match="literal_block[@language='shell' or @language='console']|
+                       literal[@classes='sp_cli']">
     <screen>
       <xsl:apply-templates/>
     </screen>
@@ -632,7 +633,7 @@
     </entry>
   </xsl:template>
 
-  <xsl:template match="entry/*[not(self::paragraph)]" mode="table">
+  <xsl:template match="entry/*[not(self::paragraph or self::bullet_list)]" mode="table">
     <para>
       <xsl:apply-templates/>
     </para>
@@ -952,6 +953,11 @@
   <xsl:template match="reference[@refid]">
     <xref linkend="{@refid}"/>
   </xsl:template>
+
+  <xsl:template match="entry/inline">
+    <para><xsl:apply-templates/></para>
+  </xsl:template>
+
 
   <xsl:template match="entry/inline/reference[@refid]">
     <link xl:href="#{@refid}"><xsl:apply-templates/></link>

--- a/tests/data/table-002.params.json
+++ b/tests/data/table-002.params.json
@@ -1,0 +1,5 @@
+[
+    ["count(//d:tgroup/d:colspec)", 4],
+    ["boolean(//d:tbody/d:row[1]/d:entry[1]/d:itemizedlist/d:listitem)", true],
+    ["boolean(//d:tbody/d:row[1]/d:entry[1]/d:itemizedlist/d:listitem/d:screen)", true]
+]

--- a/tests/data/table-002.xml
+++ b/tests/data/table-002.xml
@@ -1,0 +1,33 @@
+<!--<!DOCTYPE document PUBLIC
+  "+//IDN docutils.sourceforge.net//DTD Docutils Generic//EN//XML"
+  "http://docutils.sourceforge.net/docs/ref/docutils.dtd">-->
+
+<document source="table.002.rst">
+  <target refid="table"/>
+  <section ids="table table" names="test\ tables tables">
+    <title>Test Table</title>
+    <paragraph/>
+
+    <table>
+      <tgroup>
+        <colspec colwidth="1"/>
+        <colspec colwidth="1"/>
+        <colspec colwidth="1"/>
+        <colspec colwidth="1"/>
+        <tbody>
+          <row>
+            <entry>
+              <bullet_list><list_item><literal classes="sp_cli">foo --os-username=&lt;username&gt; --os-user-domain-name=&lt;domain&gt;
+--os-password=&lt;password&gt; token issue</literal></list_item></bullet_list>
+            </entry>
+            <entry>
+              <inline classes="sp_feature_mandatory">mandatory</inline>
+            </entry>
+            <entry/>
+            <entry/>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </section>
+</document>


### PR DESCRIPTION
Fixes #63 

Changes proposed in this pull request:

* Add template for `literal[@classes='sp_cli']`
* Add testcases
