### PR TITLE
Revisit #61, move @cols from table -> tgroup

### DIFF
--- a/src/rstxml2db/rstxml2db.xsl
+++ b/src/rstxml2db/rstxml2db.xsl
@@ -565,9 +565,6 @@
       <xsl:if test="$title != '' and $tabletype = 'table'">
         <xsl:copy-of select="$title"/>
       </xsl:if>
-      <xsl:attribute name="cols">
-       <xsl:value-of select="count(tgroup/colspec)"/>
-      </xsl:attribute>
       <xsl:apply-templates mode="table"/>
     </xsl:element>
   </xsl:template>
@@ -622,6 +619,9 @@
 
   <xsl:template match="tgroup" mode="table">
     <tgroup>
+       <xsl:attribute name="cols">
+         <xsl:value-of select="count(colspec)"/>
+      </xsl:attribute>
       <xsl:apply-templates mode="table"/>
     </tgroup>
   </xsl:template>

--- a/tests/data/table-without-cols.params.json
+++ b/tests/data/table-without-cols.params.json
@@ -1,4 +1,4 @@
 [
-    ["//d:informaltable/@cols", ["4"]],
-    ["//d:informaltable/@cols = count(//d:tgroup/d:colspec)", true]
+    ["//d:informaltable/d:tgroup/@cols", ["4"]],
+    ["//d:informaltable/d:tgroup/@cols = count(//d:tgroup/d:colspec)", true]
 ]


### PR DESCRIPTION
Fixes #61 

Changes proposed in this pull request:

* Move `@cols` attribute from `table`/`informaltable` to `tgroup`
* Adapt testcases
