### PR TITLE
Fix #64: Add missing doctest_block template

### DIFF
--- a/src/rstxml2db/rstxml2db.xsl
+++ b/src/rstxml2db/rstxml2db.xsl
@@ -354,7 +354,8 @@
   </xsl:template>
 
   <xsl:template match="literal_block[@language='shell' or @language='console']|
-                       literal[@classes='sp_cli']">
+                       literal[@classes='sp_cli']|
+                       doctest_block">
     <screen>
       <xsl:apply-templates/>
     </screen>

--- a/tests/data/docktest_block-001.params.json
+++ b/tests/data/docktest_block-001.params.json
@@ -1,0 +1,4 @@
+[
+    ["//d:variablelist/d:varlistentry/d:term/text()", ["Term"]],
+    ["//d:variablelist/d:varlistentry/d:listitem/d:screen/text()", ["Screen"]]
+]

--- a/tests/data/docktest_block-001.xml
+++ b/tests/data/docktest_block-001.xml
@@ -1,0 +1,19 @@
+<!--
+<!DOCTYPE document PUBLIC
+  "+//IDN docutils.sourceforge.net//DTD Docutils Generic//EN//XML"
+  "http://docutils.sourceforge.net/docs/ref/docutils.dtd">
+-->
+
+<document source="docktest_block.001.rst">
+ <section ids="bullet.list">
+  <title>Definition List</title>
+  <definition_list>
+     <definition_list_item>
+        <term>Term</term>
+        <definition>
+           <doctest_block xml:space="preserve">Screen</doctest_block>
+        </definition>
+     </definition_list_item>
+  </definition_list>
+ </section>
+</document>


### PR DESCRIPTION
Fixes #64 

Changes proposed in this pull request:

* Add missing template for `doctest_block`
* Add testcases
