### PR TITLE
Fix #68: Deal with strong|literal in list_item

### DIFF
--- a/src/rstxml2db/rstxml2db.xsl
+++ b/src/rstxml2db/rstxml2db.xsl
@@ -355,9 +355,10 @@
     <xsl:apply-templates/>
   </xsl:template>
 
-  <xsl:template match="literal_block[@language='shell' or @language='console']|
-                       literal[@classes='sp_cli']|
-                       doctest_block">
+  <xsl:template match="literal_block
+                       | literal_block[@language='shell' or @language='console']
+                       | literal[@classes='sp_cli']
+                       | doctest_block" name="screen">
     <screen>
       <xsl:apply-templates/>
     </screen>
@@ -370,12 +371,6 @@
   </xsl:template>
 
   <xsl:template match="line_block[line[normalize-space(.)='']]"/>
-
-  <xsl:template match="literal_block">
-    <screen>
-      <xsl:apply-templates/>
-    </screen>
-  </xsl:template>
 
   <xsl:template match="note|tip|warning|caution|important">
     <xsl:variable name="name">
@@ -408,16 +403,23 @@
     </listitem>
   </xsl:template>
 
-  <xsl:template match="list_item/strong">
-    <para>
-      <xsl:call-template name="strong"/>
-    </para>
-  </xsl:template>
-
- <xsl:template match="list_item/literal">
-    <para>
-      <xsl:call-template name="literal"/>
-    </para>
+  <xsl:template match="list_item/*">
+    <xsl:variable name="content">
+        <para>
+            <xsl:choose>
+                <xsl:when test="self::literal">
+                    <xsl:call-template name="literal"/>
+                </xsl:when>
+                <xsl:when test="self::strong">
+                    <xsl:call-template name="strong"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:apply-templates/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </para>
+    </xsl:variable>
+    <xsl:copy-of select="$content"/>
   </xsl:template>
 
   <xsl:template match="enumerated_list">

--- a/src/rstxml2db/rstxml2db.xsl
+++ b/src/rstxml2db/rstxml2db.xsl
@@ -408,6 +408,18 @@
     </listitem>
   </xsl:template>
 
+  <xsl:template match="list_item/strong">
+    <para>
+      <xsl:call-template name="strong"/>
+    </para>
+  </xsl:template>
+
+ <xsl:template match="list_item/literal">
+    <para>
+      <xsl:call-template name="literal"/>
+    </para>
+  </xsl:template>
+
   <xsl:template match="enumerated_list">
     <procedure>
       <xsl:apply-templates/>
@@ -894,13 +906,13 @@
     </command>
   </xsl:template>
 
-  <xsl:template match="strong">
+  <xsl:template match="strong" name="strong">
     <emphasis role="bold">
       <xsl:apply-templates/>
     </emphasis>
   </xsl:template>
 
-  <xsl:template match="literal|literal_strong">
+  <xsl:template match="literal|literal_strong" name="literal">
     <literal>
       <xsl:apply-templates/>
     </literal>

--- a/tests/data/list-003.params.json
+++ b/tests/data/list-003.params.json
@@ -1,0 +1,4 @@
+[
+    ["//d:itemizedlist/d:listitem/d:para[1]/d:emphasis/text()", ["Strong"]],
+    ["//d:itemizedlist/d:listitem/d:para[2]/d:literal/text()",  ["Literal"]]
+]

--- a/tests/data/list-003.xml
+++ b/tests/data/list-003.xml
@@ -1,0 +1,17 @@
+<!--
+<!DOCTYPE document PUBLIC
+  "+//IDN docutils.sourceforge.net//DTD Docutils Generic//EN//XML"
+  "http://docutils.sourceforge.net/docs/ref/docutils.dtd">
+-->
+
+<document source="list.003.rst">
+ <section ids="bullet.list">
+  <title>Bullet List</title>
+  <bullet_list>
+   <list_item>
+    <strong>Strong</strong>
+    <literal>Literal</literal>
+   </list_item>
+  </bullet_list>
+ </section>
+</document>

--- a/tests/data/table-002.xml
+++ b/tests/data/table-002.xml
@@ -17,11 +17,12 @@
         <tbody>
           <row>
             <entry>
-              <bullet_list><list_item><literal classes="sp_cli">foo --os-username=&lt;username&gt; --os-user-domain-name=&lt;domain&gt;
---os-password=&lt;password&gt; token issue</literal></list_item></bullet_list>
+              <bullet_list>
+                  <list_item><literal classes="sp_cli">foo</literal></list_item>
+              </bullet_list>
             </entry>
             <entry>
-              <inline classes="sp_feature_mandatory">mandatory</inline>
+              <inline>Second</inline>
             </entry>
             <entry/>
             <entry/>


### PR DESCRIPTION
Fixes #68 

Changes proposed in this pull request:

* Add missing template for `list_item/strong` and `list_item/literal`
* Add testcases
