### PR TITLE
Move block elements outside of paragraph

### DIFF
--- a/src/rstxml2db/core.py
+++ b/src/rstxml2db/core.py
@@ -42,8 +42,11 @@ XSLTRST2DB = os.path.join(HERE, 'rstxml2db.xsl')
 #: file into one, single RST XML file
 XSLTRESOLVE = os.path.join(HERE, 'resolve.xsl')
 
-#: Stylesheet to spli up the XML file
+#: Stylesheet to split up the XML file
 XSLTSPLIT = os.path.join(HERE, 'split_xml.xsl')
+
+#: Stylesheet to move block elements out of <paragraph>
+XSLTMOVEBLOCKS = os.path.join(HERE, 'move-blocks-outof-para.xsl')
 
 #: Namespace mappings
 NSMAP = dict(xi='http://www.w3.org/2001/XInclude',

--- a/src/rstxml2db/move-blocks-outof-para.xsl
+++ b/src/rstxml2db/move-blocks-outof-para.xsl
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Purpose:
+     Moves block elements inside <paragraphs> outside of <paragraphs>.
+
+   Parameters:
+     None
+
+   Input:
+     RST XML file, converted with sphinx-build using option -b xml
+
+   Output:
+     RST XML file
+
+   Example:
+     See https://github.com/openSUSE/rstxml2docbook/issues/76
+
+   Author:
+     Thomas Schraitle <toms AT opensuse.org>
+     Copyright 2018 SUSE Linux GmbH
+
+-->
+<!DOCTYPE xsl:stylesheet
+[
+ <!ENTITY dbselfblocks "self::admonition |
+                        self::attention |
+                        self::block_quote |
+                        self::bullet_list |
+                        self::caution |
+                        self::danger |
+                        self::definition_list |
+                        self::doctest_block |
+                        self::enumerated_list |
+                        self::error |
+                        self::field_list |
+                        self::figure |
+                        self::hint |
+                        self::important |
+                        self::line_block |
+                        self::literal_block |
+                        self::math_block |
+                        self::note |
+                        self::option_list |
+                        self::warning">
+ <!ENTITY dbblocksinpara "paragraph/admonition |
+                          paragraph/attention |
+                          paragraph/block_quote |
+                          paragraph/bullet_list |
+                          paragraph/caution |
+                          paragraph/danger |
+                          paragraph/definition_list |
+                          paragraph/doctest_block |
+                          paragraph/enumerated_list |
+                          paragraph/error |
+                          paragraph/field_list |
+                          paragraph/figure |
+                          paragraph/hint |
+                          paragraph/important |
+                          paragraph/line_block |
+                          paragraph/literal_block |
+                          paragraph/math_block |
+                          paragraph/note |
+                          paragraph/option_list |
+                          paragraph/warning">
+]>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+ xmlns:exsl="http://exslt.org/common" exclude-result-prefixes="exsl">
+
+ <xsl:strip-space elements="paragraph"/>
+ <xsl:preserve-space elements="literal_block"/>
+ <xsl:output indent="yes"/>
+
+ <!-- copy template==================================================== -->
+ <xsl:template match="node() | @*">
+  <xsl:copy>
+   <xsl:apply-templates select="@* | node()"/>
+  </xsl:copy>
+ </xsl:template>
+
+
+ <!-- Templates ======================================================= -->
+ <xsl:template match="paragraph">
+  <xsl:apply-templates select="node()[1]"/>
+ </xsl:template>
+
+ <xsl:template match="&dbblocksinpara;">
+  <xsl:copy-of select="."/>
+  <xsl:text>&#10;</xsl:text>
+  <xsl:apply-templates select="following-sibling::node()[1]"/>
+ </xsl:template>
+ 
+ <xsl:template match="paragraph/*|paragraph/text()">
+  <xsl:element name="{local-name(..)}">
+   <xsl:apply-templates select="." mode="copy"/>
+  </xsl:element>
+  <xsl:text>&#10;</xsl:text>
+  <xsl:apply-templates
+   select="following-sibling::*[&dbselfblocks;][1]"/>
+ </xsl:template>
+ 
+ <xsl:template match="paragraph/node()" mode="copy">
+  <xsl:copy-of select="."/>
+  <xsl:if test="not(following-sibling::node()[1][&dbselfblocks;])">
+   <xsl:apply-templates select="following-sibling::node()[1]" mode="copy"/>
+  </xsl:if>
+ </xsl:template>
+</xsl:stylesheet>

--- a/src/rstxml2db/xml/process.py
+++ b/src/rstxml2db/xml/process.py
@@ -27,7 +27,7 @@ import os
 from .util import quoteparams
 from .struct import addchapter, addlegalnotice
 from ..cleanup import cleanupxml
-from ..core import XSLTRST2DB, XSLTRESOLVE, XSLTSPLIT
+from ..core import XSLTRST2DB, XSLTRESOLVE, XSLTSPLIT, XSLTMOVEBLOCKS
 
 
 log = logging.getLogger(__name__)
@@ -47,6 +47,70 @@ def logging_xslt(resultxslt, logger=log):
         log.log(getattr(logging, level, 'INFO'), "%s", msg)
 
 
+def step_blockelements_transform(tree, args):
+    """Moves block elements inside <paragraphs> outside
+       of <paragraphs>
+
+    :param tree: tree of class :class:`lxml.etree._ElementTree`
+    :param args: argument result from :class:`argparse`
+    :return: XML tree
+    :rtype: :class:`lxml.etree._ElementTree`
+    """
+    xslt = etree.XSLT(etree.parse(XSLTMOVEBLOCKS))
+    log.debug("Starting to cleanup paragraphs")
+    xml = xslt(tree)
+    return xml
+
+
+def step_resolve_transform(tree, args):
+    """Resolve any outgoing references in the RST XML document
+
+    :param tree: tree of class :class:`lxml.etree._ElementTree`
+    :param args: argument result from :class:`argparse`
+    :return: XML tree
+    :rtype: :class:`lxml.etree._ElementTree`
+    """
+    xslt = etree.XSLT(etree.parse(XSLTRESOLVE))
+    log.debug("Starting to resolve multiple RST XML "
+              "into a single RST XML file")
+    xml = xslt(tree)
+    # logging_xslt(xslt)
+    # log.debug("Resolved all external references")
+    # xml.write(
+    #    '/tmp/trees/resolve-tree.xml',
+    #    encoding='utf-8',
+    #    pretty_print=True,
+    #    )
+    # log.debug("Wrote resolved tree to '/tmp/tree.xml'")
+    log.debug("Created single RST XML file")
+    return xml
+
+
+def step_rst2db_transform(tree, args):
+    """Transform RST XML into DocBook 5
+
+    :param tree: tree of class :class:`lxml.etree._ElementTree`
+    :param args: argument result from :class:`argparse`
+    :return: XML tree
+    :rtype: :class:`lxml.etree._ElementTree`
+    """
+    xslt = etree.XSLT(etree.parse(XSLTRST2DB))
+    xml = xslt(tree, **dict(args.params))
+    # xml.write(
+    #    '/tmp/trees/db5-tree.xml',
+    #    encoding='utf-8',
+    #    pretty_print=True,
+    #    )
+    # log.debug("Wrote result tree to '/tmp/result-tree.xml'")
+    log.debug("Transformed RST XML into DocBook 5")
+    logging_xslt(xslt)
+    if args.legalnotice is not None:
+        addlegalnotice(xml, args.legalnotice)
+    if args.conventions is not None:
+        addchapter(xml, args.conventions)
+    return xml
+
+
 def transform(doc, args):
     """Transformation step
 
@@ -55,44 +119,10 @@ def transform(doc, args):
     :return: XML tree
     :rtype: :class:`lxml.etree._ElementTree`
     """
-    rstresolve_xslt = etree.parse(XSLTRESOLVE)
-    rst2db_xslt = etree.parse(XSLTRST2DB)
 
-    # Create XSLT object of both tree structures
-    resolve_trans = etree.XSLT(rstresolve_xslt)
-    rst2db_trans = etree.XSLT(rst2db_xslt)
-
-    log.debug("Starting to resolve multiple RST XML into a single RST XML file")
-    # (1) Resolve multiple RST XML -> single RST XML structure...
-    #
-    rst = resolve_trans(doc)
-    # logging_xslt(resolve_trans)
-    # log.debug("Resolved all external references")
-    # rst.write(
-    #    '/tmp/trees/resolve-tree.xml',
-    #    encoding='utf-8',
-    #    pretty_print=True,
-    #    )
-    # log.debug("Wrote resolved tree to '/tmp/tree.xml'")
-    log.debug("Created single RST XML file")
-
-    # (2) Transform RST XML -> DocBook 5
-    xml = rst2db_trans(rst, **dict(args.params))
-    # xml.write(
-    #    '/tmp/trees/db5-tree.xml',
-    #    encoding='utf-8',
-    #    pretty_print=True,
-    #    )
-    # log.debug("Wrote result tree to '/tmp/result-tree.xml'")
-    log.debug("Transformed RST XML into DocBook 5")
-
-    logging_xslt(rst2db_trans)
-    if args.legalnotice is not None:
-        addlegalnotice(xml, args.legalnotice)
-    if args.conventions is not None:
-        addchapter(xml, args.conventions)
-
-    # Cleanup
+    xml = step_resolve_transform(doc, args)
+    xml = step_blockelements_transform(xml, args)
+    xml = step_rst2db_transform(xml, args)
     cleanupxml(xml)
 
     if not args.nsplit:

--- a/tests/data/paragraph-with-block.params.json
+++ b/tests/data/paragraph-with-block.params.json
@@ -1,0 +1,7 @@
+[
+  ["boolean(/*/d:para)", true],
+  ["boolean(/*/d:itemizedlist)", true],
+  ["boolean(/*/*[3][self::d:para])", true],
+  ["boolean(/*/*[4][self::d:itemizedlist])", true],
+  ["boolean(/*/*[5][self::d:para])", true]
+]

--- a/tests/data/paragraph-with-block.xml
+++ b/tests/data/paragraph-with-block.xml
@@ -1,0 +1,10 @@
+<document source="paragraph-with-block.rst">
+    <section ids="para_with_block " names="paragraph\ with\ block\ elements">
+  <title>Paragraph With Block Elements</title>
+  <paragraph>Dog<bullet_list bullet="*">
+      <list_item>
+       <paragraph>First item</paragraph>
+      </list_item>
+   </bullet_list>Fox</paragraph>
+ </section>
+</document>

--- a/tests/test_step_transform.py
+++ b/tests/test_step_transform.py
@@ -1,0 +1,26 @@
+from rstxml2db.xml.process import step_blockelements_transform
+from lxml import etree
+
+from py.path import local
+
+DATADIR = local(__file__).parts()[-2] / "data"
+
+def test_block_in_para():
+    """xmlstr = '''<document source="paragraph-with-block.rst">
+    <section ids="para_with_block " names="paragraph\ with\ block\ elements">
+  <title>Paragraph With Block Elements</title>
+  <paragraph>Dog<bullet_list bullet="*">
+      <list_item>
+       <paragraph>First item</paragraph>
+      </list_item>
+   </bullet_list>Fox</paragraph>
+ </section>
+</document>'''"""
+    xmlstr = (DATADIR / "paragraph-with-block.xml").read()
+    xml = etree.fromstring(xmlstr)
+    result = step_blockelements_transform(xml, {})
+    # First element is <title>
+    assert result.xpath("/*/*/*[2][self::paragraph]")
+    assert result.xpath("/*/*/*[3][self::bullet_list]")
+    assert result.xpath("/*/*/*[4][self::paragraph]")
+    assert result.xpath("/*/*/bullet_list/list_item/paragraph/text()") == ['First item']


### PR DESCRIPTION
Fixes #76 

Changes proposed in this pull request:

* Move block elements outside of paragraph:
  * Split `transform()` function into several sub-transform functions (starting name with "step_*")
  * Introduce new `step_blockelements_transform()` function to move block elements outside of `<paragraph>` (done by the stylesheet `move-blocks-outof-para.xsl`)
* Add testcases
