### PR TITLE
Split transform() function

### DIFF
--- a/src/rstxml2db/xml/process.py
+++ b/src/rstxml2db/xml/process.py
@@ -46,6 +46,7 @@ def logging_xslt(resultxslt, logger=log):
         msg = msg.strip()
         log.log(getattr(logging, level, 'INFO'), "%s", msg)
 
+
 def step_resolve_transform(tree, args):
     """Resolve any outgoing references in the RST XML document
     :param tree: tree of class :class:`lxml.etree._ElementTree`

--- a/src/rstxml2db/xml/process.py
+++ b/src/rstxml2db/xml/process.py
@@ -46,6 +46,52 @@ def logging_xslt(resultxslt, logger=log):
         msg = msg.strip()
         log.log(getattr(logging, level, 'INFO'), "%s", msg)
 
+def step_resolve_transform(tree, args):
+    """Resolve any outgoing references in the RST XML document
+    :param tree: tree of class :class:`lxml.etree._ElementTree`
+    :param args: argument result from :class:`argparse`
+    :return: XML tree
+    :rtype: :class:`lxml.etree._ElementTree`
+    """
+    xslt = etree.XSLT(etree.parse(XSLTRESOLVE))
+    log.debug("Starting to resolve multiple RST XML "
+              "into a single RST XML file")
+    xml = xslt(tree)
+    # logging_xslt(xslt)
+    # log.debug("Resolved all external references")
+    # xml.write(
+    #    '/tmp/trees/resolve-tree.xml',
+    #    encoding='utf-8',
+    #    pretty_print=True,
+    #    )
+    # log.debug("Wrote resolved tree to '/tmp/tree.xml'")
+    log.debug("Created single RST XML file")
+    return xml
+
+
+def step_rst2db_transform(tree, args):
+    """Transform RST XML into DocBook 5
+    :param tree: tree of class :class:`lxml.etree._ElementTree`
+    :param args: argument result from :class:`argparse`
+    :return: XML tree
+    :rtype: :class:`lxml.etree._ElementTree`
+    """
+    xslt = etree.XSLT(etree.parse(XSLTRST2DB))
+    xml = xslt(tree, **dict(args.params))
+    # xml.write(
+    #    '/tmp/trees/db5-tree.xml',
+    #    encoding='utf-8',
+    #    pretty_print=True,
+    #    )
+    # log.debug("Wrote result tree to '/tmp/result-tree.xml'")
+    log.debug("Transformed RST XML into DocBook 5")
+    logging_xslt(xslt)
+    if args.legalnotice is not None:
+        addlegalnotice(xml, args.legalnotice)
+    if args.conventions is not None:
+        addchapter(xml, args.conventions)
+    return xml
+
 
 def transform(doc, args):
     """Transformation step
@@ -55,44 +101,8 @@ def transform(doc, args):
     :return: XML tree
     :rtype: :class:`lxml.etree._ElementTree`
     """
-    rstresolve_xslt = etree.parse(XSLTRESOLVE)
-    rst2db_xslt = etree.parse(XSLTRST2DB)
-
-    # Create XSLT object of both tree structures
-    resolve_trans = etree.XSLT(rstresolve_xslt)
-    rst2db_trans = etree.XSLT(rst2db_xslt)
-
-    log.debug("Starting to resolve multiple RST XML into a single RST XML file")
-    # (1) Resolve multiple RST XML -> single RST XML structure...
-    #
-    rst = resolve_trans(doc)
-    # logging_xslt(resolve_trans)
-    # log.debug("Resolved all external references")
-    # rst.write(
-    #    '/tmp/trees/resolve-tree.xml',
-    #    encoding='utf-8',
-    #    pretty_print=True,
-    #    )
-    # log.debug("Wrote resolved tree to '/tmp/tree.xml'")
-    log.debug("Created single RST XML file")
-
-    # (2) Transform RST XML -> DocBook 5
-    xml = rst2db_trans(rst, **dict(args.params))
-    # xml.write(
-    #    '/tmp/trees/db5-tree.xml',
-    #    encoding='utf-8',
-    #    pretty_print=True,
-    #    )
-    # log.debug("Wrote result tree to '/tmp/result-tree.xml'")
-    log.debug("Transformed RST XML into DocBook 5")
-
-    logging_xslt(rst2db_trans)
-    if args.legalnotice is not None:
-        addlegalnotice(xml, args.legalnotice)
-    if args.conventions is not None:
-        addchapter(xml, args.conventions)
-
-    # Cleanup
+    xml = step_resolve_transform(doc, args)
+    xml = step_rst2db_transform(xml, args)
     cleanupxml(xml)
 
     if not args.nsplit:


### PR DESCRIPTION
Changes proposed in this pull request:

* Split `transform()` into several sub-transform functions (starting name with "step_*")
* no additional testcases added, just refactoring
