### PR TITLE
Improve list-003 testcase

### DIFF
--- a/tests/data/list-003.params.json
+++ b/tests/data/list-003.params.json
@@ -1,4 +1,6 @@
 [
     ["//d:itemizedlist/d:listitem/d:para[1]/d:emphasis/text()", ["Strong"]],
-    ["//d:itemizedlist/d:listitem/d:para[2]/d:literal/text()",  ["Literal"]]
+    ["//d:itemizedlist/d:listitem/d:para[2]/d:literal/text()",  ["Literal"]],
+    ["//d:itemizedlist/d:listitem/d:para[3]/d:emphasis/text()",  ["Emphasis"]],
+    ["//d:itemizedlist/d:listitem/d:screen/text()",  ["Screen"]]
 ]

--- a/tests/data/list-003.xml
+++ b/tests/data/list-003.xml
@@ -11,6 +11,8 @@
    <list_item>
     <strong>Strong</strong>
     <literal>Literal</literal>
+    <emphasis>Emphasis</emphasis>
+    <literal classes='sp_cli'>Screen</literal>
    </list_item>
   </bullet_list>
  </section>


### PR DESCRIPTION
Add literal and emphasis after paragraph

Changes proposed in this pull request:

* Add `literal` and `emphasis` after `paragraph`
