### PR TITLE
Fix #43: catch XSLTApplyError exception

### DIFF
--- a/src/rstxml2db/cli.py
+++ b/src/rstxml2db/cli.py
@@ -252,10 +252,13 @@ def main(cliargs=None):
         args = parsecli(cliargs)
         return process(args)
 
-    except (etree.XMLSyntaxError) as error:
+    except etree.XMLSyntaxError as error:
         log.fatal("%s in file %r", error, args.indexfile)  # exc_info=error, stack_info=True
         return ERROR_CODES.get(repr(type(error)), 255)
-
+    except etree.XSLTApplyError as error:
+        log.fatal(error)
+        log.fatal("Check for possible syntax errors in the respective file")
+        return ERROR_CODES.get(repr(type(error)), 255)
     except (FileNotFoundError, OSError) as error:
         log.fatal(error)
         return ERROR_CODES.get(repr(type(error)), 255)

--- a/tests/test_filenotfound.py
+++ b/tests/test_filenotfound.py
@@ -1,7 +1,9 @@
 
 import pytest
-from rstxml2db.xml.process import process
+from rstxml2db.xml.process import process, transform
 from rstxml2db.common import ERROR_CODES
+
+from lxml import etree
 
 
 def test_filenotfound1(args):
@@ -19,3 +21,33 @@ def test_filenotfound2():
 
     result = main(['-o', 'result.xml', 'file-does-not-exist.xml'])
     assert result == ERROR_CODES[FileNotFoundError]
+
+
+def test_catch_XSLTApplyError(args):
+    def create_xml_tree():
+        xml = """<document source="doc/source/admin/index.rst">
+ <section ids="test-guide" names="test\ guide">
+  <title>Test Guide</title>
+  <compound classes="toctree-wrapper">
+  <compact_paragraph toctree="True">
+    <bullet_list>
+    <list_item classes="toctree-l1">
+      <compact_paragraph classes="toctree-l1">
+       <reference anchorname="" internal="True" refuri="unknown-file"
+       >File which does not exist</reference>
+      </compact_paragraph>
+     </list_item>
+    </bullet_list>
+   </compact_paragraph>
+  </compound>
+  </section>
+</document>
+"""
+        return etree.fromstring(xml).getroottree()
+
+    args.output = 'result.xml'
+    args.indexfile = 'fake-index.xml'
+
+    doc = create_xml_tree()
+    with pytest.raises(etree.XSLTApplyError):
+        result = transform(doc, args)


### PR DESCRIPTION
Fixes #43

Changes proposed in this pull request:

* Catch a XSLTApplyError exception
* Give hints in the error message
* adapt testcase

Needed, when a RST XML file contains a reference to a file which contains syntax errors.