### PR TITLE
Remove Python 3.4 for Tox/Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,19 +14,19 @@ stages:
 jobs:
     include:
         - stage: check
-          python: 3.4
-          env: TOXENV=check
+          python: 3.5
           install: skip
           script: tox -v
-        - stage: test
-          python: 3.4
-          env: TOXENV=py34
+          env: TOXENV=check
         - stage: test
           python: 3.5
           env: TOXENV=py35
         - stage: test
           python: 3.6
           env: TOXENV=py36
+        - stage: test
+          python: 3.7
+          env: TOXENV=py37
         - stage: doc
           python: 3.6
           script:

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,14 +32,9 @@ exclude = .env/*,.tmp/*,doc/*,tests/*,build/*,.pyenv/*
 
 [tool:pytest]
 norecursedirs = .git build .env/ env/ .pyenv/ .tmp/
-addopts =
-    --ignore=.env/
-    --ignore=.tmp/
-    --ignore=.git/
-    --ignore=.tox/
-    --ignore=.pyenv/
-    --ignore=test_*.txt
+testpaths = tests
+ addopts =
     --no-cov-on-fail
     --cov=rstxml2db
     --cov-report=term-missing
-    # --showlocals
+    --showlocals

--- a/src/rstxml2db/cleanup.py
+++ b/src/rstxml2db/cleanup.py
@@ -106,13 +106,13 @@ def add_pi_in_screen(xml, limit=83, target='dbsuse-fo', fontsize='8pt'):
     """
     tree = xml.getroottree() if hasattr(xml, 'getroottree') else xml
     for screen in tree.iter('screen'):
-            if screen.text is not None and any([len(i) > limit
-                                                for i in screen.text.split("\n")]):
-                pi = etree.ProcessingInstruction(target,
-                                                 'font-size="{}"'.format(fontsize))
-                pi.tail = screen.text
-                screen.text = ''
-                screen.insert(0, pi)
+        if screen.text is not None and \
+           any([len(i) > limit for i in screen.text.split("\n")]):
+            pi = etree.ProcessingInstruction(target,
+                                             'font-size="{}"'.format(fontsize))
+            pi.tail = screen.text
+            screen.text = ''
+            screen.insert(0, pi)
 
 
 def remove_double_ids(xml, usedoubleids=True):

--- a/tox.ini
+++ b/tox.ini
@@ -2,18 +2,12 @@
 [tox]
 envlist =
     check
-    py34
     py35
     py36
     py37
 
 [testenv]
-basepython =
-    check: python
-    py34:  python3.4
-    py35:  python3.5
-    py36: python3.6
-    py37:  python3.7
+basepython = python3
 passenv =
     # See https://github.com/codecov/codecov-python/blob/5b9d539a6a09bc84501b381b563956295478651a/README.md#using-tox
     codecov: TOXENV


### PR DESCRIPTION
Changes proposed in this pull request:

* Remove support for Python 3.4 for Tox & Travis
* `tox.ini`: Simplify `basepython` entry.
* Correct indendation in `cleanup.py`